### PR TITLE
solve the glue.qt not available for version>0.7 problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Sphinx & coverage
+build
+doc/_build
+doc/api
+glue/tests/htmlcov
+*.coverage
+*htmlcov*
+
+# Packages/installer info
+doc/.eggs
+Glue.egg-info
+glueviz.egg-info
+dist
+
+# Compiled files
+*.pyc
+
+# Other generated files
+glue/_githash.py
+
+# Other
+.pylintrc
+*.ropeproject
+glue/qt/glue_qt_resources.py
+*.__junk*
+*.orig
+*~
+.cache
+
+# Mac OSX
+.DS_Store
+
+# PyCharm
+.idea
+
+# Eclipse editor project files
+.project
+.pydevproject
+.settings

--- a/glue_exp/importers/vizier/qt_widget.py
+++ b/glue_exp/importers/vizier/qt_widget.py
@@ -2,7 +2,7 @@ import os
 
 from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
-from glue.qt.qtutil import load_ui
+from glue.utils.qt.helpers import load_ui
 
 from .vizier_helpers import query_vizier, fetch_vizier_catalog
 

--- a/glue_exp/importers/webcam/qt_widget.py
+++ b/glue_exp/importers/webcam/qt_widget.py
@@ -1,7 +1,7 @@
 import os
 
 from glue.external.qt import QtGui, QtCore
-from glue.qt.qtutil import load_ui
+from glue.utils.qt.helpers import load_ui
 
 from .webcam_helpers import Webcam, frame_to_data
 

--- a/glue_exp/tools/contour_selection/__init__.py
+++ b/glue_exp/tools/contour_selection/__init__.py
@@ -2,7 +2,7 @@ def setup():
 
     from glue.logger import logger
     from glue.config import tool_registry
-    from glue.qt.widgets.image_widget import ImageWidget
+    from glue.viewers.image.qt import ImageWidget
 
     from .contour_selection import ContourSelectionTool
 

--- a/glue_exp/tools/contour_selection/contour_selection.py
+++ b/glue_exp/tools/contour_selection/contour_selection.py
@@ -1,6 +1,6 @@
 import os
 
-from glue.qt.mouse_mode import MouseMode
+from glue.viewers.common.qt.mouse_mode import MouseMode
 from glue.core import roi
 from glue.external.qt import QtGui
 

--- a/glue_exp/tools/contour_selection/contour_selection.py
+++ b/glue_exp/tools/contour_selection/contour_selection.py
@@ -33,7 +33,7 @@ class ContourSelectionTool(object):
 
         if im is None or att is None:
             return
-        if im.size > WARN_THRESH and not self._confirm_large_image(im):
+        if im.size > WARN_THRESH and not self.widget._confirm_large_image(im):
             return
 
         roi = mode.roi(im[att])

--- a/glue_exp/tools/contour_selection/tests/test_contour_selection.py
+++ b/glue_exp/tools/contour_selection/tests/test_contour_selection.py
@@ -1,7 +1,7 @@
 import numpy as np
 from mock import MagicMock, patch
 
-from glue.qt.tests.test_mouse_mode import TestMouseMode, Event
+from glue.viewers.common.qt.tests.test_mouse_mode import TestMouseMode, Event
 
 from ..contour_selection import ContourMode, contour_to_roi
 


### PR DESCRIPTION
For https://github.com/glue-viz/glue-3d-viewer/issues/86
# TODO: This package works well on 2D image under current Glue, but doesn't support data sets which have more than 2 dimensions.
