### PR TITLE
Enable the contour extraction for 3D data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Sphinx & coverage
+build
+doc/_build
+doc/api
+glue/tests/htmlcov
+*.coverage
+*htmlcov*
+
+# Packages/installer info
+doc/.eggs
+Glue.egg-info
+glueviz.egg-info
+dist
+
+# Compiled files
+*.pyc
+
+# Other generated files
+glue/_githash.py
+
+# Other
+.pylintrc
+*.ropeproject
+glue/qt/glue_qt_resources.py
+*.__junk*
+*.orig
+*~
+.cache
+
+# Mac OSX
+.DS_Store
+
+# PyCharm
+.idea
+
+# Eclipse editor project files
+.project
+.pydevproject
+.settings

--- a/glue_exp/importers/vizier/qt_widget.py
+++ b/glue_exp/importers/vizier/qt_widget.py
@@ -2,7 +2,7 @@ import os
 
 from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
-from glue.qt.qtutil import load_ui
+from glue.utils.qt.helpers import load_ui
 
 from .vizier_helpers import query_vizier, fetch_vizier_catalog
 

--- a/glue_exp/importers/webcam/qt_widget.py
+++ b/glue_exp/importers/webcam/qt_widget.py
@@ -1,7 +1,7 @@
 import os
 
 from glue.external.qt import QtGui, QtCore
-from glue.qt.qtutil import load_ui
+from glue.utils.qt.helpers import load_ui
 
 from .webcam_helpers import Webcam, frame_to_data
 

--- a/glue_exp/tools/contour_selection/__init__.py
+++ b/glue_exp/tools/contour_selection/__init__.py
@@ -2,7 +2,7 @@ def setup():
 
     from glue.logger import logger
     from glue.config import tool_registry
-    from glue.qt.widgets.image_widget import ImageWidget
+    from glue.viewers.image.qt import ImageWidget
 
     from .contour_selection import ContourSelectionTool
 

--- a/glue_exp/tools/contour_selection/contour_selection.py
+++ b/glue_exp/tools/contour_selection/contour_selection.py
@@ -1,6 +1,6 @@
 import os
 
-from glue.qt.mouse_mode import MouseMode
+from glue.viewers.common.qt.mouse_mode import MouseMode
 from glue.core import roi
 from glue.external.qt import QtGui
 

--- a/glue_exp/tools/contour_selection/contour_selection.py
+++ b/glue_exp/tools/contour_selection/contour_selection.py
@@ -33,7 +33,7 @@ class ContourSelectionTool(object):
 
         if im is None or att is None:
             return
-        if im.size > WARN_THRESH and not self._confirm_large_image(im):
+        if im.size > WARN_THRESH and not self.widget._confirm_large_image(im):
             return
 
         roi = mode.roi(im[att])

--- a/glue_exp/tools/contour_selection/contour_selection.py
+++ b/glue_exp/tools/contour_selection/contour_selection.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 
 from glue.viewers.common.qt.mouse_mode import MouseMode
 from glue.core import roi
@@ -35,10 +36,28 @@ class ContourSelectionTool(object):
             return
         if im.size > WARN_THRESH and not self.widget._confirm_large_image(im):
             return
+        slc = self.widget.client.slice
 
-        roi = mode.roi(im[att])
+        # attribute is Primary,
+        data = np.take(im[att], slc[self.profile_axis], axis=self.profile_axis)
+
+        # when mouse pos of xy and axis status shown on left selection panel doesn't match
+        # TODO: this would be solved when switch axis labels and its value
+        if slc.index('x') < slc.index('y'):
+            data = data.transpose()
+
+        roi = mode.roi(data)
         if roi:
             self.widget.apply_roi(roi)
+
+    @property
+    def profile_axis(self):
+        # XXX make this settable
+        # defaults to the non-xy axis with the most channels
+        slc = self.widget.client.slice
+        candidates = [i for i, s in enumerate(slc) if s not in ['x', 'y']]
+
+        return max(candidates, key=lambda i: self.widget.client.display_data.shape[i])
 
     def _display_data_hook(self, data):
         pass
@@ -76,6 +95,8 @@ class ContourMode(MouseMode):
             A new ROI made by the (single) contour that passes through the
             mouse location (and `None` if this could not be calculated)
         """
+        # here the xy refers to the x and y related to the order of left panel
+
         x, y = self._event_xdata, self._event_ydata
         return contour_to_roi(x, y, data)
 

--- a/glue_exp/tools/contour_selection/tests/test_contour_selection.py
+++ b/glue_exp/tools/contour_selection/tests/test_contour_selection.py
@@ -1,7 +1,7 @@
 import numpy as np
 from mock import MagicMock, patch
 
-from glue.qt.tests.test_mouse_mode import TestMouseMode, Event
+from glue.viewers.common.qt.tests.test_mouse_mode import TestMouseMode, Event
 
 from ..contour_selection import ContourMode, contour_to_roi
 


### PR DESCRIPTION
As above and the demo figure shown below, one improvement is that the contour selection now is based on current slice and won't get updated when the slice is changed. @astrofrog Could you move this repo to the main Glue that I could try to add a `callback` for the slider bar? Thanks!
#7 should be merged before this PR :)

![851423091_8075302077850595795](https://cloud.githubusercontent.com/assets/13411839/16172786/6963e852-355d-11e6-8168-bc5b04aa6ac0.jpg)
