### PR TITLE
Ignore egg from setup.py install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ glue/tests/htmlcov
 doc/.eggs
 Glue.egg-info
 glueviz.egg-info
+glue_exp.egg-info
 dist
 
 # Compiled files


### PR DESCRIPTION
Ignore generated `egg` for `glue-exp` from `setup.py install`.
